### PR TITLE
Keyboard handling re-write/update

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+* Version 1.1
+
+- Rewrite of keyboard handling code (Will now support keyboard combinations such as Ctrl + C)
+- Minor code clean-up
+
 * Version 1.0
 
 - Added ZRLE (Grégoire Pailler) using the BSD licensed zlib.NET version 1.04 (http://www.componentace.com/zlib_NET.htm)

--- a/VncSharp.Nuget/ReadMe.txt
+++ b/VncSharp.Nuget/ReadMe.txt
@@ -1,3 +1,9 @@
+VncSharp NuGet project Prereqs
+==============================
+Requires the "NuBuild Project System" Extension for Visual Studio
+https://visualstudiogallery.msdn.microsoft.com/3efbfdea-7d51-4d45-a954-74a2df51c5d0
+
+
 VncSharp : How to Use in a Windows Forms App
 ============================================
 

--- a/VncSharp/Encodings/ZrleRectangle.cs
+++ b/VncSharp/Encodings/ZrleRectangle.cs
@@ -16,9 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
-using System.IO.Compression;
 
 namespace VncSharp.Encodings
 {
@@ -30,8 +27,8 @@ namespace VncSharp.Encodings
 		private const int TILE_WIDTH = 64;
 		private const int TILE_HEIGHT = 64;
 
-		private int[] palette = new int[128];
-		private int[] tileBuffer = new int[TILE_WIDTH * TILE_HEIGHT];
+		private readonly int[] palette = new int[128];
+		private readonly int[] tileBuffer = new int[TILE_WIDTH * TILE_HEIGHT];
 
 		public ZrleRectangle(RfbProtocol rfb, Framebuffer framebuffer, Rectangle rectangle)
 			: base(rfb, framebuffer, rectangle, RfbProtocol.ZRLE_ENCODING)

--- a/VncSharp/KeyboardHook.cs
+++ b/VncSharp/KeyboardHook.cs
@@ -1,0 +1,276 @@
+﻿/*
+ * Based on code from Stephen Toub's MSDN blog at
+ * http://blogs.msdn.com/b/toub/archive/2006/05/03/589423.aspx
+ * 
+ * Originally written by https://github.com/rmcardle for https://github.com/mRemoteNG/VncSharpNG
+ * Additional fixes and porting to (upstream) https://github.com/humphd/VncSharp by https://github.com/kmscode
+ */
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
+namespace VncSharp
+{
+    public class KeyboardHook
+    {
+        // ReSharper disable InconsistentNaming
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool PostMessage(IntPtr hWnd, Int32 Msg, IntPtr wParam, HookKeyMsgData lParam);
+        // ReSharper restore InconsistentNaming
+
+        [Flags]
+        public enum ModifierKeys
+        {
+            None = 0x0000,
+            Shift = 0x0001,
+            LeftShift = 0x002,
+            RightShift = 0x004,
+            Control = 0x0008,
+            LeftControl = 0x010,
+            RightControl = 0x20,
+            Alt = 0x0040,
+            LeftAlt = 0x0080,
+            RightAlt = 0x0100,
+            Win = 0x0200,
+            LeftWin = 0x0400,
+            RightWin = 0x0800,
+        }
+
+        protected class KeyNotificationEntry: IEquatable<KeyNotificationEntry>
+        {
+            public IntPtr WindowHandle;
+            public Int32 KeyCode;
+            public ModifierKeys ModifierKeys;
+            public Boolean Block;
+
+            public bool Equals(KeyNotificationEntry obj)
+            {
+                return (WindowHandle == obj.WindowHandle &&
+                        KeyCode == obj.KeyCode &&
+                        ModifierKeys == obj.ModifierKeys &&
+                        Block == obj.Block);
+            }
+        }
+
+        private const string HookKeyMsgName = "HOOKKEYMSG-{EC4E5587-8F3A-4A56-A00B-2A5F827ABA79}";
+        private static Int32 _hookKeyMsg;
+        public static Int32 HookKeyMsg
+        {
+            get
+            {
+                if (_hookKeyMsg == 0)
+                {
+                    _hookKeyMsg = Win32.RegisterWindowMessage(HookKeyMsgName).ToInt32();
+                    if (_hookKeyMsg == 0)
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+                return _hookKeyMsg;
+            }
+        }
+
+        // this is a custom structure that will be passed to
+        // the requested hWnd via a WM_APP_HOOKKEYMSG message
+        [StructLayout(LayoutKind.Sequential)]
+        public class HookKeyMsgData
+        {
+            public Int32 KeyCode;
+            public ModifierKeys ModifierKeys;
+            public Boolean WasBlocked;
+        }
+
+        private static int _referenceCount;
+        private static IntPtr _hook;
+        private static readonly Win32.LowLevelKeyboardProcDelegate LowLevelKeyboardProcStaticDelegate = LowLevelKeyboardProc;
+        private static readonly List<KeyNotificationEntry> NotificationEntries = new List<KeyNotificationEntry>();
+
+        public KeyboardHook()
+        {
+            _referenceCount++;
+            SetHook();
+        }
+
+        ~KeyboardHook()
+        {
+            _referenceCount--;
+            if (_referenceCount < 1) UnsetHook();
+        }
+
+        private static void SetHook()
+        {
+            if (_hook != IntPtr.Zero) return;
+
+            var curProcess = Process.GetCurrentProcess();
+            var curModule = curProcess.MainModule;
+
+            var hook = Win32.SetWindowsHookEx(Win32.WH_KEYBOARD_LL, LowLevelKeyboardProcStaticDelegate, Win32.GetModuleHandle(curModule.ModuleName), 0);
+            if (hook == IntPtr.Zero)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            _hook = hook;
+        }
+
+        private static void UnsetHook()
+        {
+            if (_hook == IntPtr.Zero) return;
+
+            Win32.UnhookWindowsHookEx(_hook);
+            _hook = IntPtr.Zero;
+        }
+
+        private static IntPtr LowLevelKeyboardProc(Int32 nCode, IntPtr wParam, Win32.KBDLLHOOKSTRUCT lParam)
+        {
+            var wParamInt = wParam.ToInt32();
+            var result = 0;
+
+            if (nCode == Win32.HC_ACTION)
+            {
+                switch (wParamInt)
+                {
+                    case Win32.WM_KEYDOWN:
+                    case Win32.WM_SYSKEYDOWN:
+                    case Win32.WM_KEYUP:
+                    case Win32.WM_SYSKEYUP:
+                        result = OnKey(wParamInt, lParam);
+                        break;
+                }
+            }
+
+            if (result != 0) return new IntPtr(result);
+
+            return Win32.CallNextHookEx(_hook, nCode, wParam, lParam);
+        }
+
+        private static int OnKey(Int32 msg, Win32.KBDLLHOOKSTRUCT key)
+        {
+            var result = 0;
+
+            foreach (var notificationEntry in NotificationEntries)
+                // It error code is Null, have to ignore the exception
+                // For some unknow raison, sometime GetFocuseWindows throw an exception
+                // Mainly when the station is unlocked, or after an admin password is asked
+                try
+                {
+                    if (GetFocusWindow() == notificationEntry.WindowHandle && notificationEntry.KeyCode == key.vkCode)
+                    {
+                        var modifierKeys = GetModifierKeyState();
+                        if (!ModifierKeysMatch(notificationEntry.ModifierKeys, modifierKeys)) continue;
+
+                        var wParam = new IntPtr(msg);
+                        var lParam = new HookKeyMsgData
+                        {
+                            KeyCode = key.vkCode,
+                            ModifierKeys = modifierKeys,
+                            WasBlocked = notificationEntry.Block,
+                        };
+
+                        if (!PostMessage(notificationEntry.WindowHandle, HookKeyMsg, wParam, lParam))
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+                        if (notificationEntry.Block) result = 1;
+                    }
+                }
+                catch (Win32Exception e)
+                {
+                    if (e.NativeErrorCode != 0)
+                    {
+                        throw;
+                    }
+                }
+
+            return result;
+        }
+
+        private static IntPtr GetFocusWindow()
+        {
+            var guiThreadInfo = new Win32.GUITHREADINFO();
+            if (!Win32.GetGUIThreadInfo(0, guiThreadInfo))
+            {
+                var except = Marshal.GetLastWin32Error();
+                throw new Win32Exception(except);
+            }
+            return Win32.GetAncestor(guiThreadInfo.hwndFocus, Win32.GA_ROOT);
+        }
+
+        private static readonly Dictionary<Int32, ModifierKeys> ModifierKeyTable = new Dictionary<Int32, ModifierKeys>
+        {
+            { Win32.VK_SHIFT, ModifierKeys.Shift },
+            { Win32.VK_LSHIFT, ModifierKeys.LeftShift },
+            { Win32.VK_RSHIFT, ModifierKeys.RightShift },
+            { Win32.VK_CONTROL, ModifierKeys.Control },
+            { Win32.VK_LCONTROL, ModifierKeys.LeftControl },
+            { Win32.VK_RCONTROL, ModifierKeys.RightControl },
+            { Win32.VK_MENU, ModifierKeys.Alt },
+            { Win32.VK_LMENU, ModifierKeys.LeftAlt },
+            { Win32.VK_RMENU, ModifierKeys.RightAlt },
+            { Win32.VK_LWIN, ModifierKeys.LeftWin },
+            { Win32.VK_RWIN, ModifierKeys.RightWin },
+        };
+
+        public static ModifierKeys GetModifierKeyState()
+        {
+            var modifierKeyState = ModifierKeys.None;
+
+            foreach (KeyValuePair<Int32, ModifierKeys> pair in ModifierKeyTable)
+            {
+                if ((Win32.GetAsyncKeyState(pair.Key) & Win32.KEYSTATE_PRESSED) != 0) modifierKeyState |= pair.Value;
+            }
+
+            if ((modifierKeyState & ModifierKeys.LeftWin) != 0) modifierKeyState |= ModifierKeys.Win;
+            if ((modifierKeyState & ModifierKeys.RightWin) != 0) modifierKeyState |= ModifierKeys.Win;
+
+            return modifierKeyState;
+        }
+
+        private static Boolean ModifierKeysMatch(ModifierKeys requestedKeys, ModifierKeys pressedKeys)
+        {
+            if ((requestedKeys & ModifierKeys.Shift) != 0) pressedKeys &= ~(ModifierKeys.LeftShift | ModifierKeys.RightShift);
+            if ((requestedKeys & ModifierKeys.Control) != 0) pressedKeys &= ~(ModifierKeys.LeftControl | ModifierKeys.RightControl);
+            if ((requestedKeys & ModifierKeys.Alt) != 0) pressedKeys &= ~(ModifierKeys.LeftAlt | ModifierKeys.RightAlt);
+            if ((requestedKeys & ModifierKeys.Win) != 0) pressedKeys &= ~(ModifierKeys.LeftWin | ModifierKeys.RightWin);
+            return requestedKeys == pressedKeys;
+        }
+
+        public static void RequestKeyNotification(IntPtr windowHandle, Int32 keyCode, Boolean block)
+        {
+            RequestKeyNotification(windowHandle, keyCode, ModifierKeys.None, block);
+        }
+
+        public static void RequestKeyNotification(IntPtr windowHandle, Int32 keyCode, ModifierKeys modifierKeys = ModifierKeys.None, Boolean block = false)
+        {
+            var newNotificationEntry = new KeyNotificationEntry
+            {
+                WindowHandle = windowHandle,
+                KeyCode = keyCode,
+                ModifierKeys = modifierKeys,
+                Block = block,
+            };
+
+            foreach (var notificationEntry in NotificationEntries)
+                if (notificationEntry == newNotificationEntry) return;
+
+            NotificationEntries.Add(newNotificationEntry);
+        }
+
+        public static void CancelKeyNotification(IntPtr windowHandle, Int32 keyCode, Boolean block)
+        {
+            CancelKeyNotification(windowHandle, keyCode, ModifierKeys.None, block);
+        }
+
+        private static void CancelKeyNotification(IntPtr windowHandle, Int32 keyCode, ModifierKeys modifierKeys = ModifierKeys.None, Boolean block = false)
+        {
+            var notificationEntry = new KeyNotificationEntry
+            {
+                WindowHandle = windowHandle,
+                KeyCode = keyCode,
+                ModifierKeys = modifierKeys,
+                Block = block,
+            };
+
+            NotificationEntries.Remove(notificationEntry);
+        }
+    }
+}

--- a/VncSharp/Properties/AssemblyInfo.cs
+++ b/VncSharp/Properties/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 
-[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyVersion("1.1.0")]

--- a/VncSharp/RemoteDesktop.cs
+++ b/VncSharp/RemoteDesktop.cs
@@ -17,14 +17,12 @@
 
 using System;
 using System.Drawing;
-using System.Threading;
-using System.Reflection;
 using System.Windows.Forms;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing.Imaging;
-using System.Drawing.Drawing2D;
-
-using VncSharp.Encodings;
+using static System.Reflection.Assembly;
+#pragma warning disable 1587,1584,1711,1572,1581,1580
 
 namespace VncSharp
 {
@@ -74,17 +72,17 @@ namespace VncSharp
         /// </summary>
         public event EventHandler   ClipboardChanged;
 
-		/// <summary>
-		/// Points to a Function capable of obtaining a user's password.  By default this means using the PasswordDialog.GetPassword() function; however, users of RemoteDesktop can replace this with any function they like, so long as it matches the delegate type.
-		/// </summary>
-		public AuthenticateDelegate GetPassword;
+        /// <summary>
+        /// Points to a Function capable of obtaining a user's password.  By default this means using the PasswordDialog.GetPassword() function; however, users of RemoteDesktop can replace this with any function they like, so long as it matches the delegate type.
+        /// </summary>
+        public AuthenticateDelegate GetPassword;
 		
 		Bitmap desktop;						     // Internal representation of remote image.
 		Image  designModeDesktop;			     // Used when painting control in VS.NET designer
 		VncClient vnc;						     // The Client object handling all protocol-level interaction
 		int port = 5900;					     // The port to connect to on remote host (5900 is default)
-		bool passwordPending = false;		     // After Connect() is called, a password might be required.
-		bool fullScreenRefresh = false;		     // Whether or not to request the entire remote screen be sent.
+		bool passwordPending;		     // After Connect() is called, a password might be required.
+		bool fullScreenRefresh;		     // Whether or not to request the entire remote screen be sent.
         VncDesktopTransformPolicy desktopPolicy;
 		RuntimeState state = RuntimeState.Disconnected;
 
@@ -95,7 +93,7 @@ namespace VncSharp
 			Connecting
 		}
 		
-		public RemoteDesktop() : base()
+		public RemoteDesktop()
 		{
 			// Since this control will be updated constantly, and all graphics will be drawn by this class,
 			// set the control's painting for best user-drawn performance.
@@ -108,7 +106,7 @@ namespace VncSharp
 					 true);
 
 			// Show a screenshot of a Windows desktop from the manifest and cache to be used when painting in design mode
-			designModeDesktop = Image.FromStream(Assembly.GetAssembly(GetType()).GetManifestResourceStream("VncSharp.Resources.screenshot.png"));
+			designModeDesktop = Image.FromStream(GetAssembly(GetType()).GetManifestResourceStream("VncSharp.Resources.screenshot.png"));
 			
             // Use a simple desktop policy for design mode.  This will be replaced in Connect()
             desktopPolicy = new VncDesignModeDesktopPolicy(this);
@@ -116,15 +114,15 @@ namespace VncSharp
             AutoScrollMinSize = desktopPolicy.AutoScrollMinSize;
 
 			// Users of the control can choose to use their own Authentication GetPassword() method via the delegate above.  This is a default only.
-			GetPassword = new AuthenticateDelegate(PasswordDialog.GetPassword);
+			GetPassword = PasswordDialog.GetPassword;
 		}
 		
 		[DefaultValue(5900)]
 		[Description("The port number used by the VNC Host (typically 5900)")]
-		/// <summary>
-		/// The port number used by the VNC Host (typically 5900).
-		/// </summary>
-		public int VncPort {
+        /// <summary>
+        /// The port number used by the VNC Host (typically 5900).
+        /// </summary>
+        public int VncPort {
 			get { 
 				return port; 
 			}
@@ -138,7 +136,7 @@ namespace VncSharp
 		/// <summary>
 		/// True if the RemoteDesktop is connected and authenticated (if necessary) with a remote VNC Host; otherwise False.
 		/// </summary>
-		public bool IsConnected {
+		private bool IsConnected {
 			get {
 				return state == RuntimeState.Connected;
 			}
@@ -149,7 +147,7 @@ namespace VncSharp
 		// First check to see if the control is in DesignMode, then work up 
 		// to also check any parent controls.  DesignMode returns False sometimes
 		// when it is really True for the parent. Thanks to Claes Bergefall for the idea.
-		protected new bool DesignMode {
+	    private new bool DesignMode {
 			get {
 				if (base.DesignMode) {
 					return true;
@@ -240,7 +238,7 @@ namespace VncSharp
 		// EncodedRectangle object is passed via the VncEventArgs (actually an IDesktopUpdater
 		// object so that *only* Draw() can be called here--Decode() is done elsewhere).
 		// The VncClient object handles thread marshalling onto the UI thread.
-		protected void VncUpdate(object sender, VncEventArgs e)
+	    private void VncUpdate(object sender, VncEventArgs e)
 		{
 			e.DesktopUpdater.Draw(desktop);
             Invalidate(desktopPolicy.AdjustUpdateRectangle(e.DesktopUpdater.UpdateRectangle));
@@ -338,29 +336,27 @@ namespace VncSharp
             // indicates the end of the connection, maybe that would be a better design.
             InsureConnection(false);
 
-            if (host == null) throw new ArgumentNullException("host");
-            if (display < 0) throw new ArgumentOutOfRangeException("display", display, "Display number must be a positive integer.");
+            if (host == null) throw new ArgumentNullException(nameof(host));
+            if (display < 0) throw new ArgumentOutOfRangeException(nameof(display), display, "Display number must be a positive integer.");
 
             // Start protocol-level handling and determine whether a password is needed
             vnc = new VncClient();
-            vnc.ConnectionLost += new EventHandler(VncClientConnectionLost);
-            vnc.ServerCutText += new EventHandler(VncServerCutText);
+            vnc.ConnectionLost += VncClientConnectionLost;
+            vnc.ServerCutText += VncServerCutText;
 
             passwordPending = vnc.Connect(host, display, VncPort, viewOnly);
 
             SetScalingMode(scaled);
 
-            if (passwordPending) {
+            if (passwordPending)
+            {
                 // Server needs a password, so call which ever method is refered to by the GetPassword delegate.
                 string password = GetPassword();
 
-                if (password == null) {
-                    // No password could be obtained (e.g., user clicked Cancel), so stop connecting
-                    return;
-                } else {
+                if (password != null)
                     Authenticate(password);
-                }
-            } else {
+            }
+            else {
                 // No password needed, so go ahead and Initialize here
                 Initialize();
             }
@@ -372,7 +368,7 @@ namespace VncSharp
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is already Connected.  See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>
 		/// <exception cref="System.NullReferenceException">Thrown if the password is null.</exception>
 		/// <param name="password">The user's password.</param>
-		public void Authenticate(string password)
+		private void Authenticate(string password)
 		{
 			InsureConnection(false);
 			if (!passwordPending) throw new InvalidOperationException("Authentication is only required when Connect() returns True and the VNC Host requires a password.");
@@ -395,11 +391,28 @@ namespace VncSharp
             vnc.SetInputMode(viewOnly);
         }
 
+        [DefaultValue(false)]
+        [Description("True if view-only mode is desired (no mouse/keyboard events will be sent)")]
+        /// <summary>
+        /// True if view-only mode is desired (no mouse/keyboard events will be sent).
+        /// </summary>
+        public bool ViewOnly
+        {
+            get
+            {
+                return vnc.IsViewOnly;
+            }
+            set
+            {
+                SetInputMode(value);
+            }
+        }
+        
         /// <summary>
         /// Set the remote desktop's scaling mode.
         /// </summary>
         /// <param name="scaled">Determines whether to use desktop scaling or leave it normal and clip.</param>
-        public void SetScalingMode(bool scaled)
+        private void SetScalingMode(bool scaled)
         {
             if (scaled) {
                 desktopPolicy = new VncScaledDesktopPolicy(vnc, this);
@@ -413,11 +426,28 @@ namespace VncSharp
             Invalidate();
         }
 
+        [DefaultValue(false)]
+        [Description("Determines whether to use desktop scaling or leave it normal and clip")]
+        /// <summary>
+        /// Determines whether to use desktop scaling or leave it normal and clip.
+        /// </summary>
+        public bool Scaled
+        {
+            get
+            {
+                return desktopPolicy.GetType() == typeof(VncScaledDesktopPolicy);
+            }
+            set
+            {
+                SetScalingMode(value);
+            }
+        }
+
 		/// <summary>
 		/// After protocol-level initialization and connecting is complete, the local GUI objects have to be set-up, and requests for updates to the remote host begun.
 		/// </summary>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is already in the Connected state.  See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>		
-		protected void Initialize()
+		private void Initialize()
 		{
 			// Finish protocol handshake with host now that authentication is done.
 			InsureConnection(false);
@@ -437,7 +467,7 @@ namespace VncSharp
             AutoScrollMinSize = desktopPolicy.AutoScrollMinSize;
 
 			// Start getting updates from the remote host (vnc.StartUpdates will begin a worker thread).
-			vnc.VncUpdate += new VncUpdateHandler(VncUpdate);
+			vnc.VncUpdate += VncUpdate;
 			vnc.StartUpdates();
 		}
 
@@ -452,7 +482,7 @@ namespace VncSharp
 					Cursor = new Cursor(GetType(), "Resources.vnccursor.cur");
 					break;
 				// All other states should use the normal cursor.
-				case RuntimeState.Disconnected:
+				//case RuntimeState.Disconnected:
 				default:	
 					Cursor = Cursors.Default;				
 					break;
@@ -463,7 +493,7 @@ namespace VncSharp
 		/// Creates and initially sets-up the local bitmap that will represent the remote desktop image.
 		/// </summary>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not already in the Connected state. See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>
-		protected void SetupDesktop()
+		private void SetupDesktop()
 		{
 			InsureConnection(true);
 
@@ -481,7 +511,7 @@ namespace VncSharp
 		/// Draws the given message (white text) on the local desktop (all black).
 		/// </summary>
 		/// <param name="message">The message to be drawn.</param>
-		protected void DrawDesktopMessage(string message)
+		private void DrawDesktopMessage(string message)
 		{
 			System.Diagnostics.Debug.Assert(desktop != null, "Can't draw on desktop when null.");
 			// Draw the given message on the local desktop
@@ -499,16 +529,16 @@ namespace VncSharp
 			}
 
 		}
-		
-		/// <summary>
-		/// Stops the remote host from sending further updates and disconnects.
-		/// </summary>
-		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not already in the Connected state. See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>
-		public void Disconnect()
+
+        /// <summary>
+        /// Stops the remote host from sending further updates and disconnects.
+        /// </summary>
+        /// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not already in the Connected state. See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>
+        public void Disconnect()
 		{
 			InsureConnection(true);
-			vnc.ConnectionLost -= new EventHandler(VncClientConnectionLost);
-            vnc.ServerCutText -= new EventHandler(VncServerCutText);
+			vnc.ConnectionLost -= VncClientConnectionLost;
+            vnc.ServerCutText -= VncServerCutText;
 			vnc.Disconnect();
 			SetState(RuntimeState.Disconnected);
 			OnConnectionLost();
@@ -527,7 +557,7 @@ namespace VncSharp
         /// Fills the remote server's clipboard with text.
         /// </summary>
         /// <param name="text">The text to put in the server's clipboard.</param>
-        public void FillServerClipboard(string text)
+        private void FillServerClipboard(string text)
         {
             vnc.WriteClientCutText(text);
         }
@@ -595,7 +625,7 @@ namespace VncSharp
 		/// <param name="desktopImage">The desktop image to be drawn to the control's sufrace.</param>
 		/// <param name="g">The Graphics object representing the control's drawable surface.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not already in the Connected state.</exception>
-		protected void DrawDesktopImage(Image desktopImage, Graphics g)
+		private void DrawDesktopImage(Image desktopImage, Graphics g)
 		{
 			g.DrawImage(desktopImage, desktopPolicy.RepositionImage(desktopImage));
 		}
@@ -605,7 +635,7 @@ namespace VncSharp
 		/// </summary>
 		/// <param name="sender">The VncClient object that raised the event.</param>
 		/// <param name="e">An empty EventArgs object.</param>
-		protected void VncClientConnectionLost(object sender, EventArgs e)
+		private void VncClientConnectionLost(object sender, EventArgs e)
 		{
 			// If the remote host dies, and there are attempts to write
 			// keyboard/mouse/update notifications, this may get called 
@@ -618,12 +648,12 @@ namespace VncSharp
 		}
 
         // Handle the VncClient ServerCutText event and bubble it up as ClipboardChanged.
-        protected void VncServerCutText(object sender, EventArgs e)
+	    private void VncServerCutText(object sender, EventArgs e)
         {
             OnClipboardChanged();
         }
 
-        protected void OnClipboardChanged()
+	    private void OnClipboardChanged()
         {
             if (ClipboardChanged != null)
                 ClipboardChanged(this, EventArgs.Empty);
@@ -634,7 +664,7 @@ namespace VncSharp
 		/// </summary>
 		/// <param name="e">An EventArgs object.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is in the Connected state.</exception>
-		protected void OnConnectionLost()
+		private void OnConnectionLost()
 		{
 			if (ConnectionLost != null) {
 				ConnectionLost(this, EventArgs.Empty);
@@ -646,7 +676,7 @@ namespace VncSharp
 		/// </summary>
 		/// <param name="e">A ConnectEventArgs object with information about the remote framebuffer's geometry.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not in the Connected state.</exception>
-		protected void OnConnectComplete(ConnectEventArgs e)
+		private void OnConnectComplete(ConnectEventArgs e)
 		{
 			if (ConnectComplete != null) {
 				ConnectComplete(this, e);
@@ -659,13 +689,7 @@ namespace VncSharp
 		// TODO: currently we don't handle the case of 3-button emulation with 2-buttons.
 		protected override void OnMouseMove(MouseEventArgs mea)
 		{
-			// Only bother if the control is connected.
-			if (IsConnected) {
-				// See if the mouse pointer is inside the area occupied by the desktop on screen.
-                Rectangle adjusted = desktopPolicy.GetMouseMoveRectangle();
-				if (adjusted.Contains(PointToClient(MousePosition)))
-					UpdateRemotePointer();
-			}
+			UpdateRemotePointer();
 			base.OnMouseMove(mea);
 		}
 
@@ -717,16 +741,14 @@ namespace VncSharp
 				Point current = PointToClient(MousePosition);
 				byte mask = 0;
 
-				if (Control.MouseButtons == MouseButtons.Left)   mask += 1;
-				if (Control.MouseButtons == MouseButtons.Middle) mask += 2;
-				if (Control.MouseButtons == MouseButtons.Right)  mask += 4;
+				if (MouseButtons == MouseButtons.Left)   mask += 1;
+				if (MouseButtons == MouseButtons.Middle) mask += 2;
+				if (MouseButtons == MouseButtons.Right)  mask += 4;
 
-                Point adjusted = desktopPolicy.UpdateRemotePointer(current);
-                if (adjusted.X < 0 || adjusted.Y < 0)
-                    throw new Exception();
-
-				vnc.WritePointerEvent(mask, desktopPolicy.UpdateRemotePointer(current));
-			}
+                Rectangle adjusted = desktopPolicy.GetMouseMoveRectangle();
+                if (adjusted.Contains(current))
+                    vnc.WritePointerEvent(mask, desktopPolicy.UpdateRemotePointer(current));
+            }
 		}
 
 		// Handle Keyboard Events:		 -------------------------------------------
@@ -753,7 +775,8 @@ namespace VncSharp
 		// ManageKeyDownAndKeyUp, OnKeyPress, OnKeyUp, OnKeyDown.
 		private void ManageKeyDownAndKeyUp(KeyEventArgs e, bool isDown)
 		{
-		    UInt32 keyChar;
+            // BUG FIX: Set default keyChar value in event of modifier key (ThrillerAtPlay)
+            uint keyChar = (uint)e.KeyCode;
 		    bool isProcessed = true;
 		    switch(e.KeyCode)
 		    {
@@ -794,16 +817,23 @@ namespace VncSharp
 			    case Keys.F10:
 			    case Keys.F11:
 			    case Keys.F12:
-				    keyChar = 0x0000FFBE + ((UInt32)e.KeyCode - (UInt32)Keys.F1);
+				    keyChar = 0x0000FFBE + ((uint)e.KeyCode - (uint)Keys.F1);
 				    break;
 			    default:
-				    keyChar = 0;
-				    isProcessed = false;
-				    break;
+                    // BUG FIX: Correctly account for modifier key (ThrillerAtPlay)
+		            if (!e.Alt && !e.Control)
+		            {
+		                keyChar = 0;
+		                isProcessed = false;
+                        Debug.Print("VNCSharp: NOT Alt or Ctrl");
+		            }
+		            break;
 		    }
 
+            Debug.Print("VNCSharp - keychar: {0}", keyChar);
 		    if(isProcessed)
 		    {
+                Debug.Print("VNCSharp: Processed keychar: {0}", keyChar);
 			    vnc.WriteKeyboardEvent(keyChar, isDown);
 			    e.Handled = true;
 		    }
@@ -822,16 +852,16 @@ namespace VncSharp
 		    if (e.Handled)
 			    return;
 	
-		    if(Char.IsLetterOrDigit(e.KeyChar) || Char.IsWhiteSpace(e.KeyChar) || Char.IsPunctuation(e.KeyChar) ||
+		    if(char.IsLetterOrDigit(e.KeyChar) || char.IsWhiteSpace(e.KeyChar) || char.IsPunctuation(e.KeyChar) ||
 			    e.KeyChar == '~' || e.KeyChar == '`' || e.KeyChar == '<' || e.KeyChar == '>' ||
 			    e.KeyChar == '|' || e.KeyChar == '=' || e.KeyChar == '+' || e.KeyChar == '$' || e.KeyChar == '^')
 		    {
-			    vnc.WriteKeyboardEvent((UInt32)e.KeyChar, true);
-			    vnc.WriteKeyboardEvent((UInt32)e.KeyChar, false);
+			    vnc.WriteKeyboardEvent(e.KeyChar, true);
+			    vnc.WriteKeyboardEvent(e.KeyChar, false);
 		    }
 		    else if(e.KeyChar == '\b')
 		    {
-			    UInt32 keyChar = ((UInt32)'\b') | 0x0000FF00;
+                uint keyChar = ((uint)'\b') | 0x0000FF00;
 			    vnc.WriteKeyboardEvent(keyChar, true);
 			    vnc.WriteKeyboardEvent(keyChar, false);
 		    }
@@ -869,7 +899,7 @@ namespace VncSharp
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not in the Connected state.</exception>
 		public void SendSpecialKeys(SpecialKeys keys)
 		{
-			this.SendSpecialKeys(keys, true);
+			SendSpecialKeys(keys, true);
 		}
 
 		/// <summary>
@@ -878,7 +908,7 @@ namespace VncSharp
 		/// <param name="keys">SpecialKeys is an enumerated list of supported keyboard combinations.</param>
 		/// <remarks>Keyboard combinations are Pressed and then Released, while single keys (e.g., SpecialKeys.Ctrl) are only pressed so that subsequent keys will be modified.</remarks>
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is not in the Connected state.</exception>
-		public void SendSpecialKeys(SpecialKeys keys, bool release)
+		private void SendSpecialKeys(SpecialKeys keys, bool release)
 		{
 			InsureConnection(true);
 			// For all of these I am sending the key presses manually instead of calling

--- a/VncSharp/VncSharp.csproj
+++ b/VncSharp/VncSharp.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="KeyboardHook.cs" />
     <Compile Include="VncDesignModeDesktopPolicy.cs" />
     <Compile Include="VncDesktopTransformPolicy.cs" />
     <Compile Include="VncScaledDesktopPolicy.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="VncEventArgs.cs" />
     <Compile Include="VncProtocolException.cs" />
     <Compile Include="VncViewInputPolicy.cs" />
+    <Compile Include="Win32.cs" />
     <Compile Include="zlib.NET\Adler32.cs" />
     <Compile Include="zlib.NET\Deflate.cs" />
     <Compile Include="zlib.NET\InfBlocks.cs" />

--- a/VncSharp/Win32.cs
+++ b/VncSharp/Win32.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace VncSharp
+{
+    // ReSharper disable InconsistentNaming
+    public static class Win32
+    {
+        #region Functions
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProcDelegate lpfn, IntPtr hMod, Int32 dwThreadId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, KBDLLHOOKSTRUCT lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr RegisterWindowMessage(string lpString);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool PostMessage(IntPtr hWnd, Int32 Msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetGUIThreadInfo(Int32 idThread, GUITHREADINFO lpgui);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern Int16 GetAsyncKeyState(Int32 vKey);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetKeyboardState(byte[] lpKeyState);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern Int32 MapVirtualKey(Int32 uCode, Int32 uMapType);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int ToAscii(Int32 uVirtKey, Int32 uScanCode, byte[] lpKeyState, byte[] lpwTransKey, Int32 fuState);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr GetAncestor(IntPtr hwnd, UInt32 gaFlags);
+
+        #endregion
+
+        #region Delegates
+
+        public delegate IntPtr LowLevelKeyboardProcDelegate(Int32 nCode, IntPtr wParam, KBDLLHOOKSTRUCT lParam);
+
+        #endregion
+
+        #region Structures
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class KBDLLHOOKSTRUCT
+        {
+            public Int32 vkCode;
+            public Int32 scanCode;
+            public Int32 flags;
+            public Int32 time;
+            public IntPtr dwExtraInfo;
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class GUITHREADINFO
+        {
+            public GUITHREADINFO()
+            {
+                cbSize = Convert.ToInt32(Marshal.SizeOf(this));
+            }
+
+            public Int32 cbSize;
+            public Int32 flags;
+            public IntPtr hwndActive;
+            public IntPtr hwndFocus;
+            public IntPtr hwndCapture;
+            public IntPtr hwndMenuOwner;
+            public IntPtr hwndMoveSize;
+            public IntPtr hwndCaret;
+            public RECT rcCaret;
+        }
+
+        #endregion
+
+        #region Constants
+        // GetAncestor
+        public const int GA_ROOT = 2;
+
+        // SetWindowsHookEx
+        public const int WH_KEYBOARD_LL = 13;
+
+        // LowLevelKeyboardProcDelegate
+        public const int HC_ACTION = 0;
+
+        // SendMessage
+        public const int WM_KEYDOWN = 0x0100;
+        public const int WM_KEYUP = 0x0101;
+        public const int WM_SYSKEYDOWN = 0x0104;
+        public const int WM_SYSKEYUP = 0x0105;
+
+        // GetAsyncKeyState
+        public const int KEYSTATE_PRESSED = 0x8000;
+
+        #region Virtual Keys
+        public const int VK_CANCEL = 0x0003;
+        public const int VK_BACK = 0x0008;
+        public const int VK_TAB = 0x0009;
+        public const int VK_CLEAR = 0x000C;
+        public const int VK_RETURN = 0x000D;
+        public const int VK_PAUSE = 0x0013;
+        public const int VK_ESCAPE = 0x001B;
+        public const int VK_SNAPSHOT = 0x002C;
+        public const int VK_INSERT = 0x002D;
+        public const int VK_DELETE = 0x002E;
+        public const int VK_HOME = 0x0024;
+        public const int VK_END = 0x0023;
+        public const int VK_PRIOR = 0x0021;
+        public const int VK_NEXT = 0x0022;
+        public const int VK_LEFT = 0x0025;
+        public const int VK_UP = 0x0026;
+        public const int VK_RIGHT = 0x0027;
+        public const int VK_DOWN = 0x0028;
+        public const int VK_SELECT = 0x0029;
+        public const int VK_PRINT = 0x002A;
+        public const int VK_EXECUTE = 0x002B;
+        public const int VK_HELP = 0x002F;
+        public const int VK_LWIN = 0x005B;
+        public const int VK_RWIN = 0x005C;
+        public const int VK_APPS = 0x005D;
+        public const int VK_F1 = 0x0070;
+        public const int VK_F2 = 0x0071;
+        public const int VK_F3 = 0x0072;
+        public const int VK_F4 = 0x0073;
+        public const int VK_F5 = 0x0074;
+        public const int VK_F6 = 0x0075;
+        public const int VK_F7 = 0x0076;
+        public const int VK_F8 = 0x0077;
+        public const int VK_F9 = 0x0078;
+        public const int VK_F10 = 0x0079;
+        public const int VK_F11 = 0x007A;
+        public const int VK_F12 = 0x007B;
+        public const int VK_SHIFT = 0x0010;
+        public const int VK_LSHIFT = 0x00A0;
+        public const int VK_RSHIFT = 0x00A1;
+        public const int VK_CONTROL = 0x0011;
+        public const int VK_LCONTROL = 0x00A2;
+        public const int VK_RCONTROL = 0x00A3;
+        public const int VK_MENU = 0x0012;
+        public const int VK_LMENU = 0x00A4;
+        public const int VK_RMENU = 0x00A5;
+
+        public const int VK_OEM_1 = 0x00BA;
+        public const int VK_OEM_2 = 0x00BF;
+        public const int VK_OEM_3 = 0x00C0;
+        public const int VK_OEM_4 = 0x00DB;
+        public const int VK_OEM_5 = 0x00DC;
+        public const int VK_OEM_6 = 0x00DD;
+        public const int VK_OEM_7 = 0x00DE;
+        public const int VK_OEM_8 = 0x00DF;
+        public const int VK_OEM_102 = 0x00E2;
+
+        #endregion
+
+        #endregion
+
+        // ReSharper restore InconsistentNaming
+    }
+}


### PR DESCRIPTION
Rewrite of keyboard handling code (Will now support keyboard combinations such as Ctrl + C)
Some other minor changes/update.

The keyboard handling code has been in [mRemoteNG 1.70 Beta 1 - 2012-02-27](https://github.com/mRemoteNG/mRemoteNG) via the [VncSharpNG library](https://github.com/mRemoteNG/VncSharpNG) and is very solid. (However, there was one recent bug fixed where an application crash would occur when locking/unlocking the system where the VncSharpNG library was loaded/running - that fix is included in this PR).

With this pull request, it effectively merges any "customizations" from VncSharpNG library into the upstream VncSharp library for anyone to use and benefit from.

Thanks!!!!
