### PR TITLE
Fix Invalid State crash in onPaint when disconnecting

### DIFF
--- a/VncSharp/RemoteDesktop.cs
+++ b/VncSharp/RemoteDesktop.cs
@@ -617,6 +617,9 @@ namespace VncSharp
 					case RuntimeState.Disconnected:
 						// Do nothing, just black background.
 						break;
+					case RuntimeState.Disconnecting:
+						// Do nothing, just black background.
+						break;
 					default:
 						// Sanity check
 						throw new NotImplementedException(string.Format("RemoteDesktop in unknown State: {0}.", state.ToString()));


### PR DESCRIPTION
From an email, a user reports a crash while server is shutting down:

```
System.NotImplementedException: RemoteDesktop in unknown State: Disconnecting.
in VncSharp.RemoteDesktop.OnPaint(PaintEventArgs pe)
in System.Windows.Forms.Control.PaintWithErrorHandling(PaintEventArgs e, Int16 layer)
in System.Windows.Forms.Control.WmPaint(Message& m)
in System.Windows.Forms.Control.WndProc(Message& m)
in System.Windows.Forms.ScrollableControl.WndProc(Message& m)
in System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m)
in System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
in System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

It looks to me like the issue is just that it's not handling the `Disconnecting` case, which this does.  If someone can test this for me (I don't have a windows box anymore) I'll land it.