### PR TITLE
Issues connecting to TightVNC Server #30

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,15 @@
 Change Log
 ----------
 
+* Version 1.1.1
+
+- Add support for differing BitsPerPixel and Depth settings, improved low bandwidth support (Len Meakin)
+- Modified network protocol writes to allow for better network capturing (Len Meakin)
+- Added Read / Write socket time out values (15s) (Len Meakin)
+- Corrected ViewOnly property (VS2017 .NET 4.5.2) (Len Meakin)
+- Changed default behaviour to allow remote desktop view to be shared between clients (Len Meakin)
+- Improved support for RealVNC Server (advertising version 4.001, set as 3.8 protocol) 
+
 * Version 1.1
 
 - Rewrite of keyboard handling code (Will now support keyboard combinations such as Ctrl + C)

--- a/VncSharp/RemoteDesktop.cs
+++ b/VncSharp/RemoteDesktop.cs
@@ -88,15 +88,15 @@ namespace VncSharp
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
         public AuthenticateDelegate GetPassword;
-
+        
         private Bitmap desktop; // Internal representation of remote image.
         private readonly Image designModeDesktop; // Used when painting control in VS.NET designer
         private VncClient vnc; // The Client object handling all protocol-level interaction
         private int port = 5900; // The port to connect to on remote host (5900 is default)
         private bool passwordPending; // After Connect() is called, a password might be required.
-        private bool fullScreenRefresh; // Whether or not to request the entire remote screen be sent.
         private VncDesktopTransformPolicy desktopPolicy;
         private RuntimeState state = RuntimeState.Disconnected;
+        private bool viewOnlyMode = false;
         private int bitsPerPixel = 0;
         private int depth = 0;
 
@@ -224,7 +224,7 @@ namespace VncSharp
         public void FullScreenUpdate()
         {
             InsureConnection(true);
-            fullScreenRefresh = true;
+            vnc.FullScreenRefresh = true;
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace VncSharp
             if (state != RuntimeState.Connected) return;
 
             // Make sure the next screen update is incremental
-            fullScreenRefresh = false;
+            vnc.FullScreenRefresh = false;
         }
 
         /// <summary>
@@ -330,7 +330,7 @@ namespace VncSharp
         /// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is already Connected.  See <see cref="VncSharp.RemoteDesktop.IsConnected" />.</exception>
         public void Connect(string host, int display)
         {
-            Connect(host, display, false);
+            Connect(host, display, viewOnlyMode);
         }
 
         /// <summary>
@@ -372,6 +372,7 @@ namespace VncSharp
             vnc = new VncClient();
             vnc.ConnectionLost += VncClientConnectionLost;
             vnc.ServerCutText += VncServerCutText;
+            vnc.ViewOnly = viewOnly;
 
             passwordPending = vnc.Connect(host, display, VncPort, viewOnly);
 
@@ -413,24 +414,15 @@ namespace VncSharp
                 OnConnectionLost();
         }
 
-        /// <summary>
-        /// Changes the input mode to view-only or interactive.
-        /// </summary>
-        /// <param name="viewOnly">True if view-only mode is desired (no mouse/keyboard events will be sent).</param>
-        public void SetInputMode(bool viewOnly)
-        {
-            vnc.SetInputMode(viewOnly);
-        }
-
-        [DefaultValue(false)]
-        [Description("True if view-only mode is desired (no mouse/keyboard events will be sent)")]
-        /// <summary>
-        /// True if view-only mode is desired (no mouse/keyboard events will be sent).
-        /// </summary>
+        //[DefaultValue(false)]
+        //[Description("True if view-only mode is desired (no mouse/keyboard events will be sent)")]
+        ///// <summary>
+        ///// True if view-only mode is desired (no mouse/keyboard events will be sent).
+        ///// </summary>
         public bool ViewOnly
         {
-            get { return vnc.IsViewOnly; }
-            set { SetInputMode(value); }
+            get { return viewOnlyMode; }
+            set { viewOnlyMode = value; }
         }
 
         /// <summary>

--- a/VncSharp/VncClient.cs
+++ b/VncSharp/VncClient.cs
@@ -35,12 +35,13 @@ namespace VncSharp
 	
 	public class VncClient
 	{
-	    private RfbProtocol rfb;			// The protocol object handling all communication with server.
-	    private byte securityType;			// The type of Security agreed upon by client/server
-	    private EncodedRectangleFactory factory;
-	    private Thread worker;				// To request and read in-coming updates from server
-	    private ManualResetEvent done;		// Used to tell the worker thread to die cleanly
-	    private IVncInputPolicy inputPolicy;// A mouse/keyboard input strategy
+		private RfbProtocol rfb;			// The protocol object handling all communication with server.
+		private byte securityType;			// The type of Security agreed upon by client/server
+		private EncodedRectangleFactory factory;
+		private Thread worker;				// To request and read in-coming updates from server
+		private ManualResetEvent done;		// Used to tell the worker thread to die cleanly
+		private IVncInputPolicy inputPolicy;// A mouse/keyboard input strategy
+		private bool viewOnlyMode = false;
 
 		/// <summary>
 		/// Raised when the connection to the remote host is lost.
@@ -48,35 +49,50 @@ namespace VncSharp
 		public event EventHandler ConnectionLost;
 
         /// <summary>
-        /// Raised when the server caused the local clipboard to be filled.
-        /// </summary>
-        public event EventHandler ServerCutText;
+		/// <summary>
+		/// Raised when the server caused the local clipboard to be filled.
+		/// </summary>
+		public event EventHandler ServerCutText;
 
-	    /// <summary>
+		/// <summary>
 		/// Gets the Framebuffer representing the remote server's desktop geometry.
 		/// </summary>
 		public Framebuffer Framebuffer { get; private set; }
 
-	    /// <summary>
-        /// Gets the hostname of the remote desktop
-        /// </summary>
-        public string HostName
-	    {
-	        get { return Framebuffer.DesktopName; }
-	    }
+		/// <summary>
+		/// Gets/Sets if full screen refresh is required (forced) from the connected server.
+		/// </summary>
+		public bool FullScreenRefresh { get; set; }
 
-	    /// <summary>
+		/// <summary>
+		/// Gets the hostname of the remote desktop
+		/// </summary>
+		public string HostName
+		{
+			get { return Framebuffer.DesktopName; }
+		}
+
+		/// <summary>
 		/// Returns True if the VncClient object is View-Only, meaning no mouse/keyboard events are being sent.
 		/// </summary>
-		public bool IsViewOnly
+		public bool ViewOnly
 	    {
-	        get { return inputPolicy is VncViewInputPolicy; }
+	        get {	return viewOnlyMode;	}
+			set {	viewOnlyMode = value;
+					// Allocate the inputPolicy if there is a connection
+					if (rfb != null)
+					{	if (viewOnlyMode)
+							inputPolicy = new VncViewInputPolicy(rfb);
+						else
+							inputPolicy = new VncDefaultInputPolicy(rfb);
+					}
+				}
 	    }
 
 	    // Just for API compat, since I've added viewOnly
 		public bool Connect(string host, int display, int port)
 		{
-			return Connect(host, display, port, false);
+			return Connect(host, display, port, viewOnlyMode);
 		}
 
 		/// <summary>
@@ -99,6 +115,7 @@ namespace VncSharp
 			
 			rfb = new RfbProtocol();
 
+			viewOnlyMode = viewOnly;
 			if (viewOnly) {
 				inputPolicy = new VncViewInputPolicy(rfb);
 			} else {
@@ -352,7 +369,8 @@ namespace VncSharp
 		/// </summary>
 		private void GetRfbUpdates()
 		{
-		    // Get the initial destkop from the host
+			// Get the initial destkop from the host
+			int connLostCount = 0;
 			RequestScreenUpdate(true);
 
 			while (true) {
@@ -404,18 +422,25 @@ namespace VncSharp
                             OnServerCutText();
                             break;
                         case RfbProtocol.SET_COLOUR_MAP_ENTRIES:
-							rfb.ReadColourMapEntry();
+                            rfb.ReadColourMapEntry();
                             break;
                     }
-					// Moved screen update request here to prevent it being called multiple times
-					// This was the case when multiple rectangles were returned by the host
-					RequestScreenUpdate(false);
-					
-                } catch {
-                    OnConnectionLost();
+                    // Moved screen update request here to prevent it being called multiple times
+                    // This was the case when multiple rectangles were returned by the host
+                    RequestScreenUpdate(FullScreenRefresh);
+                    connLostCount = 0;
+                    
+                } catch
+                {   // On the first time of no data being received we force a complete update
+                    // This is for times when the server has no update, and caused the timeout.
+                    if (connLostCount++ > 1)
+                        OnConnectionLost();
+                    else
+                        RequestScreenUpdate(true);
                 }
-			}
-		}
+                FullScreenRefresh = false;
+            }
+        }
 
 	    private void OnConnectionLost()
 		{
@@ -457,18 +482,6 @@ namespace VncSharp
 			return true;
 		}
 #endif
-
-		/// <summary>
-		/// Changes the input mode to view-only or interactive.
-		/// </summary>
-		/// <param name="viewOnly">True if view-only mode is desired (no mouse/keyboard events will be sent).</param>
-		public void SetInputMode(bool viewOnly)
-		{
-			if (viewOnly)
-				inputPolicy = new VncViewInputPolicy(rfb);
-			else
-				inputPolicy = new VncDefaultInputPolicy(rfb);
-		}
 
         public void WriteClientCutText(string text)
         {

--- a/VncSharp/VncClient.cs
+++ b/VncSharp/VncClient.cs
@@ -48,7 +48,6 @@ namespace VncSharp
 		/// </summary>
 		public event EventHandler ConnectionLost;
 
-        /// <summary>
 		/// <summary>
 		/// Raised when the server caused the local clipboard to be filled.
 		/// </summary>


### PR DESCRIPTION
Changes to the ViewOnly property to remove VS 2017 Designer issues referencing null object.
Changes for FullScreenRefresh, as this may have broken during previous BitsPerPixel changes.
Fix for incorrect connection lost event, when the server sends no data as the screen has no updates during the timeout period (experienced on PLC connection) - we force a full refresh on the first connection lost, and treat subsequent timeout as a true connection lost.
Also update Changelog with recent changes.
Recent changes also resolve the following issues:
Connection timeout #20 
Compatibility with RealVNC #2 
